### PR TITLE
cd to projects folder

### DIFF
--- a/project.sh
+++ b/project.sh
@@ -49,6 +49,7 @@ project() {
     done
 
     if [ -z "$name" ]; then
+        cd $PROJECTS_HOME
         echo -e "\n  Please specify project name"
         return 1
     fi


### PR DESCRIPTION
if no project is specified

Still considering this to be an error so:
```shell
return 1
```